### PR TITLE
Add spaces to about page

### DIFF
--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -27,7 +27,7 @@ export default function About() {
         <div style={{ padding: '8px' }} />
 
         <Subheading>
-          I’m a designer and developer, currently working on
+          I’m a designer and developer, currently working on{' '}
           <a
             href="https://spectrum.chat"
             target="_blank"
@@ -35,15 +35,15 @@ export default function About() {
           >
             Spectrum
           </a>
-          . Feel free to
+          . Feel free to{' '}
           <a
             href="https://twitter.com/brian_lovin"
             target="_blank"
             rel="noopener noreferrer"
           >
-            tweet at me
+            tweet at me{' '}
           </a>
-          or
+          or{' '}
           <a
             href="mailto:briandlovin@gmail.com"
             target="_blank"
@@ -57,7 +57,7 @@ export default function About() {
         <div style={{ padding: '8px' }} />
 
         <Subheading>
-          The code that powers this website is
+          The code that powers this website is{' '}
           <a
             href="https://github.com/brianlovin/brian-lovin-next"
             target="_blank"

--- a/pages/about/index.js
+++ b/pages/about/index.js
@@ -11,7 +11,7 @@ export default function About() {
   return (
     <Page showEmailCapture={false}>
       <Head>
-        <title>Brian Lovin · About™</title>
+        <title>Brian Lovin · About</title>
         <meta content="Brian Lovin · About" name="og:title" key="og:title" />
         <meta content="Designer" name="og:description" key="og:description" />
         <meta


### PR DESCRIPTION
Implements #26 + fixes a wrong character in the document title.

@areohbe thanks so much for spotting the bug here! I'm only overriding your PR because I'd prefer to use the `{' '}` syntax for adding spaces instead of `nbsp&;`, only because it will interface with eslint a bit better. Really appreciate it!