### PR TITLE
Use word-break: break-word to improve readability

### DIFF
--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -103,7 +103,7 @@ export const p = css`
     color: ${props => props.theme.text.link};
     text-decoration: none;
     font-weight: 500;
-    word-break: break-all;
+    word-break: break-word;
     hyphens: auto;
   }
 


### PR DESCRIPTION
Noticed that some of the links got weirdly split on mobile. This helps to break multi-word links more naturally and lets CSS automatically add hyphens when words need to be broken.

word-break: break-all             |  word-break: break-word
:-------------------------:|:-------------------------:
<img width="323" alt="word-break-break-all" src="https://user-images.githubusercontent.com/15280627/71535327-0d9fac00-28d3-11ea-970f-b66f6e24e196.png">  |  <img width="323" alt="word-break-break-word" src="https://user-images.githubusercontent.com/15280627/71535328-10020600-28d3-11ea-9231-22c48b99dcb0.png">