### PR TITLE
Possible fix for AMA Textarea resize

### DIFF
--- a/src/components/Textarea/index.tsx
+++ b/src/components/Textarea/index.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
+import styled from 'styled-components'
 import Input from '~/components/Input'
 
 export default function Textarea(props) {
+  const Input = styled.textarea`
+    resize: vertical;
+  `
   return <Input as="textarea" {...props} />
 }

--- a/src/components/Textarea/index.tsx
+++ b/src/components/Textarea/index.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react'
-import styled from 'styled-components'
 import Input from '~/components/Input'
 
-export default function Textarea(props) {
-  const Input = styled.textarea`
-    resize: vertical;
-  `
-  return <Input as="textarea" {...props} />
+interface Props {
+  style?: object
+}
+
+export default function Textarea({ style, ...rest }: Props) {
+  return (
+    <Input as="textarea" {...rest} style={{ resize: 'vertical', ...style }} />
+  )
 }

--- a/src/components/Textarea/index.tsx
+++ b/src/components/Textarea/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import Input from '~/components/Input'
 
-interface Props {
+interface Props extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   style?: object
 }
 


### PR DESCRIPTION
This PR aims to point out and propose a fix for an issue where the TextArea is currently resizeable beyond the fixed container width (screenshot below).

I can't test this fix properly because I can't seem to build this repo but I hope it helps. The issue stems from theme-ui and it should be available as a prop on the component itself.

## Screenshot
![image](https://user-images.githubusercontent.com/12908185/83180891-62ff1400-a124-11ea-9fd4-aa1090fc2e98.png)
