### PR TITLE
Adding a block to /securitychecklist about public records

### DIFF
--- a/src/data/security/index.ts
+++ b/src/data/security/index.ts
@@ -16,6 +16,7 @@ import phishing from './phishing'
 import physicalPrivacy from './physicalPrivacy'
 import geotagging from './geotagging'
 import messagingApps from './messagingApps'
+import publicRecords from './publicRecords'
 
 export default {
   passwordManager,
@@ -36,4 +37,5 @@ export default {
   messagingApps,
   phishing,
   patching,
+  publicRecords,
 }

--- a/src/data/security/publicRecords.ts
+++ b/src/data/security/publicRecords.ts
@@ -1,0 +1,25 @@
+export default {
+  id: 'publicRecords',
+  title: 'Remove your public record listings',
+  description: `Public record listing services such as Whitepages, Intelius, and BeenVerified make it easy for anyone to find information from your public records. This information can include your phone number, home address, direct relatives, and more.
+
+  \n\nSomeone with malicious intent could use this info to gain access to your online accounts or steal your identity, or create a physical threat by doxing or stalking. 
+
+  \n\nWhenever you come across a record containing your personal information, file a request to opt out of the listing service.
+  `,
+  resources: [
+    {
+      name: 'Opt out of Whitepages',
+      url:
+        'https://support.whitepages.com/hc/en-us/requests/new?ticket_form_id=580868',
+    },
+    {
+      name: 'Opt out of Intelius',
+      url: 'https://www.intelius.com/opt-out/submit/',
+    },
+    {
+      name: 'Opt out of BeenVerified',
+      url: 'https://www.beenverified.com/app/optout/search',
+    },
+  ],
+}

--- a/src/data/security/publicRecords.ts
+++ b/src/data/security/publicRecords.ts
@@ -1,7 +1,7 @@
 export default {
   id: 'publicRecords',
   title: 'Remove your public record listings',
-  description: `Public record listing services such as Whitepages, Intelius, and BeenVerified make it easy for anyone to find information from your public records. This information can include your phone number, home address, direct relatives, and more.
+  description: `Public record listing services such as Whitepages, Intelius, and BeenVerified make it easy for anyone to find your information from public records. This information can include your phone number, home address, direct relatives, and more.
 
   \n\nSomeone with malicious intent could use this info to gain access to your online accounts or steal your identity, or create a physical threat by doxing or stalking. 
 

--- a/src/graphql/types.generated.ts
+++ b/src/graphql/types.generated.ts
@@ -8,6 +8,10 @@ export type Maybe<T> = T | null
 export type Exact<T extends { [key: string]: unknown }> = {
   [K in keyof T]: T[K]
 }
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]?: Maybe<T[SubKey]> }
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]: Maybe<T[SubKey]> }
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string


### PR DESCRIPTION
I've added a block at the bottom of /securitychecklist (end of the list) about opting out from public record listing services.