### PR TITLE
Explicitly set the authentication cookie domain to brianlovin.com in prod

### DIFF
--- a/src/graphql/resolvers/mutations/auth/index.ts
+++ b/src/graphql/resolvers/mutations/auth/index.ts
@@ -14,6 +14,7 @@ export function login(_, { password }, ctx) {
 
   cookie('session', encrypted, {
     path: '/',
+    domain: process.env.NODE_ENV === 'production' ? 'brianlovin.com' : undefined,
     httpOnly: true,
     sameSite: 'strict',
     maxAge: 60 * 60 * 24 * 30,


### PR DESCRIPTION
The reason this is necessary is that by default, cookies are scoped to the domain the request is from **excluding subdomains**. By explicitly specifying a domain, the cookies are scoped to the domain **including subdomains**.

See here for more info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#domain_attribute

This should make authentication via GraphCDN work.